### PR TITLE
Demo check: Here are the changes that I made to reproduce Figures 4 and 7 from the paper

### DIFF
--- a/custom_transforms.py
+++ b/custom_transforms.py
@@ -2,7 +2,8 @@ from __future__ import division
 import torch
 import random
 import numpy as np
-from scipy.misc import imresize, imrotate
+from skimage.transform import resize, rotate
+
 
 '''Set of tranform random routines that takes list of inputs as arguments,
 in order to have random but coherent transformations.'''
@@ -80,7 +81,7 @@ class RandomRotate(object):
         else:
             assert intrinsics is not None
             rot = np.random.uniform(0,10)
-            rotated_images = [imrotate(im, rot) for im in images]
+            rotated_images = [rotate(im, rot) for im in images]
 
             return rotated_images, intrinsics
 
@@ -103,7 +104,7 @@ class RandomScaleCrop(object):
 
         output_intrinsics[0] *= x_scaling
         output_intrinsics[1] *= y_scaling
-        scaled_images = [imresize(im, (scaled_h, scaled_w)) for im in images]
+        scaled_images = [resize(im, (scaled_h, scaled_w)) for im in images]
 
         if self.h and self.w:
             in_h, in_w = self.h, self.w
@@ -132,6 +133,6 @@ class Scale(object):
 
         output_intrinsics[0] *= (scaled_w / in_w)
         output_intrinsics[1] *= (scaled_h / in_h)
-        scaled_images = [imresize(im, (scaled_h, scaled_w)) for im in images]
+        scaled_images = [resize(im, (scaled_h, scaled_w)) for im in images]
 
         return scaled_images, output_intrinsics

--- a/datasets/validation_flow.py
+++ b/datasets/validation_flow.py
@@ -5,7 +5,7 @@
 
 import torch.utils.data as data
 import numpy as np
-from scipy.misc import imread
+from skimage.io import imread
 from PIL import Image
 from path import Path
 from flowutils import flow_io

--- a/models/back2future.py
+++ b/models/back2future.py
@@ -307,9 +307,9 @@ class Model(nn.Module):
         vgrid[:,1,:,:] = 2.0*vgrid[:,1,:,:].clone()/max(H-1,1)-1.0
 
         vgrid = vgrid.permute(0,2,3,1)
-        output = nn.functional.grid_sample(x, vgrid, padding_mode='border')
+        output = nn.functional.grid_sample(x, vgrid, padding_mode='border', align_corners=True)
         mask = torch.autograd.Variable(torch.ones(x.size()), requires_grad=False).cuda()
-        mask = nn.functional.grid_sample(mask, vgrid)
+        mask = nn.functional.grid_sample(mask, vgrid, align_corners=True)
 
         # if W==128:
             # np.save('mask.npy', mask.cpu().data.numpy())

--- a/test_flow.py
+++ b/test_flow.py
@@ -157,8 +157,8 @@ def main():
 
 
 
-        if (args.output_dir is not None): #and i%10==0:
-            ind = i #ind = int(i//10)
+        if (args.output_dir is not None) and i%10==0:
+            ind = int(i//10)
             output_writer.add_image('val Dispnet Output Normalized', tensor2array(disp.data[0].cpu(), max_value=None, colormap='bone'), ind)
             output_writer.add_image('val Input', tensor2array(tgt_img[0].cpu()), i)
             output_writer.add_image('val Total Flow Output', flow_to_image(tensor2array(total_flow.data[0].cpu())), ind)

--- a/test_mask.py
+++ b/test_mask.py
@@ -108,13 +108,14 @@ def main():
     errors_bare = AverageMeter(i=len(error_names))
 
     for i, (tgt_img, ref_imgs, intrinsics, intrinsics_inv, flow_gt, obj_map_gt, semantic_map_gt) in enumerate(tqdm(val_loader)):
-        tgt_img_var = Variable(tgt_img.cuda(), volatile=True)
-        ref_imgs_var = [Variable(img.cuda(), volatile=True) for img in ref_imgs]
-        intrinsics_var = Variable(intrinsics.cuda(), volatile=True)
-        intrinsics_inv_var = Variable(intrinsics_inv.cuda(), volatile=True)
+        with torch.no_grad():
+            tgt_img_var = Variable(tgt_img.cuda())
+            ref_imgs_var = [Variable(img.cuda()) for img in ref_imgs]
+            intrinsics_var = Variable(intrinsics.cuda())
+            intrinsics_inv_var = Variable(intrinsics_inv.cuda())
 
-        flow_gt_var = Variable(flow_gt.cuda(), volatile=True)
-        obj_map_gt_var = Variable(obj_map_gt.cuda(), volatile=True)
+            flow_gt_var = Variable(flow_gt.cuda())
+            obj_map_gt_var = Variable(obj_map_gt.cuda())
 
         disp = disp_net(tgt_img_var)
         depth = 1/disp
@@ -182,13 +183,13 @@ def main():
                                     tensor2array(total_flow.data[0].cpu()) )) )
 
             row1_viz = np.hstack((tgt_img_viz, depth_viz, mask_viz))
-            viz3 = np.vstack((255*tgt_img_viz, 255*depth_viz, 255*mask_viz,
+            viz3 = np.hstack((255*tgt_img_viz, 255*depth_viz, 255*mask_viz,
                         flow_to_image(np.vstack((tensor2array(flow_fwd_non_rigid.data[0].cpu()),
                                     tensor2array(total_flow.data[0].cpu()))))))
 
-            row1_viz_im = Image.fromarray((255*row1_viz).astype('uint8'))
-            row2_viz_im = Image.fromarray((row2_viz).astype('uint8'))
-            viz3_im = Image.fromarray(viz3.astype('uint8'))
+            row1_viz_im = Image.fromarray((255*row1_viz.transpose(1, 2, 0)).astype('uint8'))
+            row2_viz_im = Image.fromarray((255*row2_viz.transpose(1, 2, 0)).astype('uint8'))
+            viz3_im = Image.fromarray(viz3.transpose(1, 2, 0).astype('uint8'))
 
             row1_viz_im.save(viz_dir/str(i).zfill(3)+'01.png')
             row2_viz_im.save(viz_dir/str(i).zfill(3)+'02.png')

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,8 @@ def opencv_rainbow(resolution=1000):
 
 COLORMAPS = {'rainbow': opencv_rainbow(),
              'magma': high_res_colormap(cm.get_cmap('magma')),
-             'bone': cm.get_cmap('bone', 10000)}
+             'bone': cm.get_cmap('bone', 10000),
+             'hot': high_res_colormap(cm.get_cmap('hot'))}
 
 
 def tensor2array(tensor, max_value=None, colormap='rainbow'):


### PR DESCRIPTION
Hi Anurag, 

Thanks for the chat recently! I thought I'd share the changes that I made to reproduce the results from the paper. I figured that maybe _if_ you find the time to review and integrate the changes, you _could_ find this useful.

As you suggested, I changed the way that `test_flow.py` calculates the masks to be identical to the way `test_mask.py` does it. Accordingly, I also had to change the defaults for the mask threshold because, in the original version, the default mask threshold was .01 for `test_flow.py` and .94 for `test_mask.py`. It is now .94 for both. The results are now very close to what you can see in the original paper! (It might take some tweaking with the threshold to make them identical.)

Some other changes (I almost forgot) I had to make along the way:

* Image reading, resizing, rotation functions are no longer present in scipy. I switched to the corresponding functions in skimage instead.
* The 'hot' colormap was missing in the visualization part.
* The behavior of `grid_sample` in PyTorch has changed. Needed to set `align_corners` accordingly to achieve old behavior.
* `volatile` is no longer supported in PyTorch. I used `with torch.no_grad`, as PyTorch suggests.
* There was something funny going on in the visualization section so that the concatenation of images failed. Perhaps the order of axes in PIL has changed.

Cheers,
Michael